### PR TITLE
Use lzo1x_decompress_safe() to avoid crash

### DIFF
--- a/lzo.go
+++ b/lzo.go
@@ -372,7 +372,7 @@ func (z *Reader) Close() error {
 
 func lzoDecompress(src []byte, dst []byte) (int, error) {
 	dstLen := len(dst)
-	err := C.lzo1x_decompress((*C.uchar)(unsafe.Pointer(&src[0])), C.lzo_uint(len(src)),
+	err := C.lzo1x_decompress_safe((*C.uchar)(unsafe.Pointer(&src[0])), C.lzo_uint(len(src)),
 		(*C.uchar)(unsafe.Pointer(&dst[0])), (*C.lzo_uint)(unsafe.Pointer(&dstLen)), nil)
 	if err != 0 {
 		return 0, errno(err)


### PR DESCRIPTION
Use lzo1x_decompress_safe() function instead of lzo1x_decompress()
to avoid crash when decompressing bad lzo file.

Signed-off-by: Yunkai Zhang <qiushu.zyk@taobao.com>